### PR TITLE
Add a few more keywords, floating-point literals, and escape hex values in strings

### DIFF
--- a/syntaxes/wasm.tmLanguage.json
+++ b/syntaxes/wasm.tmLanguage.json
@@ -98,7 +98,7 @@
 			"patterns": [
 				{
 					"name": "constant.character.escape.wasm",
-					"match": "\\\\."
+					"match": "\\\\[tnr\"'\\\\]|\\\\[0-9a-fA-F]{2}"
 				}
 			]
 		},

--- a/syntaxes/wasm.tmLanguage.json
+++ b/syntaxes/wasm.tmLanguage.json
@@ -48,7 +48,7 @@
 				},
 				{
 					"name": "variable.parameter.other.wasm",
-					"match": "(\\$){1}([\\w\\d]*)"
+					"match": "\\$[\\d\\w!#$%&'*+\\-./:<=>?@\\\\^_`|~]*"
 				},
 				{
 					"name": "variable.parameter.wasm",

--- a/syntaxes/wasm.tmLanguage.json
+++ b/syntaxes/wasm.tmLanguage.json
@@ -56,7 +56,7 @@
 			"patterns": [
 				{
 					"name": "constant.numeric.wasm",
-					"match": "[\\d]"
+					"match": "\\d+(\\.\\d+)?"
 				}
 			]
 		},

--- a/syntaxes/wasm.tmLanguage.json
+++ b/syntaxes/wasm.tmLanguage.json
@@ -87,7 +87,7 @@
 			"patterns": [
 				{
 					"name": "storage.type.wasm",
-					"match": "\\b(module|type|import|export|memory|table|start|result|param|elem|data)\\b"
+					"match": "\\b(module|type|import|export|memory|table|start|result|param|elem|data|global)\\b"
 				}
 			]
 		},
@@ -150,7 +150,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.less.wasm",
-					"match": "\\b(nop|block|loop|if|else|br|br_if|br_table|end|return|drop|select|unreachable|local)\\b"
+					"match": "\\b(nop|block|loop|if|then|else|br|br_if|br_table|end|return|drop|select|unreachable|local)\\b"
 				}
 			]
 		},

--- a/syntaxes/wasm.tmLanguage.json
+++ b/syntaxes/wasm.tmLanguage.json
@@ -150,7 +150,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.less.wasm",
-					"match": "\\b(nop|block|loop|if|then|else|br|br_if|br_table|end|return|drop|select|unreachable|local)\\b"
+					"match": "\\b(nop|block|loop|if|then|else|br|br_if|br_table|end|return|drop|select|unreachable|local|mut)\\b"
 				}
 			]
 		},

--- a/syntaxes/wasm.tmLanguage.json
+++ b/syntaxes/wasm.tmLanguage.json
@@ -49,10 +49,6 @@
 				{
 					"name": "variable.parameter.other.wasm",
 					"match": "\\$[\\d\\w!#$%&'*+\\-./:<=>?@\\\\^_`|~]*"
-				},
-				{
-					"name": "variable.parameter.wasm",
-					"match": "\\b(param)\\b"
 				}
 			]
 		},
@@ -91,7 +87,7 @@
 			"patterns": [
 				{
 					"name": "storage.type.wasm",
-					"match": "\\b(module|type|import|export|memory|table|start|result|elem|data)\\b"
+					"match": "\\b(module|type|import|export|memory|table|start|result|param|elem|data)\\b"
 				}
 			]
 		},


### PR DESCRIPTION
Hey, thanks for making this extension, it's really handy!
I noticed a few things in my code that were within the spec but didn't highlight properly so I made some contributions.
Added a few keywords, and floating-point literals. Updated the regex for identifiers to include all the non-alphanumeric characters that are allowed in the spec. Updated the regex for escaped strings to include hex values.
https://webassembly.github.io/spec/core/text/values.html 